### PR TITLE
ci: streamline release workflow with tag-based automation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,23 +1,39 @@
-name: Publish to PyPI
+name: Release
 
 on:
-  release:
-    types: [published]
-
-permissions:
-  contents: read
-  id-token: write
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-
   publish:
-    needs: ci
     runs-on: ubuntu-latest
-    environment: pypi
+    permissions:
+      id-token: write
+      contents: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-      - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Generate changelog
+        id: changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          args: --latest --strip header
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.changelog.outputs.content }}
+          files: dist/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,10 +286,6 @@ Oinker uses **Trusted Publishing (OIDC)** - no API tokens needed. PyPI verifies 
    - Owner: `major`
    - Repository: `oinker`
    - Workflow: `publish.yml`
-   - Environment: `pypi`
-
-2. **GitHub Environment**: Repository Settings → Environments → `pypi`
-   - Enable "Required reviewers" for manual approval gate
 
 ### Release Process
 
@@ -297,37 +293,27 @@ Oinker uses **Trusted Publishing (OIDC)** - no API tokens needed. PyPI verifies 
 # 1. Bump version in pyproject.toml
 #    version = "0.1.0" → "0.2.0"
 
-# 2. Commit the version bump
+# 2. Commit, tag, and push
 git commit -am "chore: bump version to 0.2.0"
-
-# 3. Create and push tag
 git tag v0.2.0
 git push && git push --tags
 
-# 4. Create GitHub Release
-#    - Go to https://github.com/major/oinker/releases/new
-#    - Select the tag (v0.2.0)
-#    - Generate release notes (or write your own)
-#    - Click "Publish release"
-
-# 5. Approve the deployment
-#    - GitHub Actions will pause at the `pypi` environment
-#    - Review and approve to publish to PyPI
+# Done! The workflow handles the rest.
 ```
 
 ### What Happens Automatically
 
-1. GitHub Release triggers `.github/workflows/publish.yml`
-2. CI runs first (lint, typecheck, test)
-3. If CI passes, `uv build` creates wheel + sdist
-4. `pypa/gh-action-pypi-publish` uploads via OIDC (no tokens!)
-5. Package appears at [pypi.org/project/oinker](https://pypi.org/project/oinker/)
+1. Git tag push triggers `.github/workflows/publish.yml`
+2. `uv build` creates wheel + sdist
+3. `pypa/gh-action-pypi-publish` uploads via OIDC (no tokens!)
+4. `git-cliff` generates changelog from Conventional Commits
+5. GitHub Release created automatically with changelog + dist files
+6. Package appears at [pypi.org/project/oinker](https://pypi.org/project/oinker/)
 
 ### Security Features
 
 | Feature | How It Works |
 |---------|--------------|
 | No long-lived tokens | OIDC tokens expire in 15 minutes |
-| Manual approval gate | GitHub Environment protection |
 | Cryptographic attestations | Automatic with gh-action-pypi-publish |
 | Audit trail | GitHub Releases show who/when |


### PR DESCRIPTION
## Summary

Simplifies the release process to match ldap-mcp's fully automated workflow.

- Trigger on git tag push (`v*`) instead of manual GitHub Release creation
- Auto-generate changelog via `git-cliff` from Conventional Commits
- Auto-create GitHub Release with changelog and dist files
- Remove manual approval gate (`environment: pypi`)
- Update AGENTS.md release documentation

## New Release Process

```bash
# 1. Bump version in pyproject.toml
# 2. Commit, tag, and push
git commit -am "chore: bump version to X.Y.Z"
git tag vX.Y.Z
git push && git push --tags
# Done! 🎉
```

## What Changes

| Before | After |
|--------|-------|
| Manual GitHub Release creation | Auto-created by workflow |
| Manual approval gate | No approval needed |
| 5 steps to release | 2 steps to release |
| Manual release notes | Auto-generated changelog |